### PR TITLE
Add Rails 5 support

### DIFF
--- a/omniauth-stable.gemspec
+++ b/omniauth-stable.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "rake"
-  spec.add_dependency 'omniauth-oauth2', "~> 1.1.0"
+  spec.add_dependency 'omniauth-oauth2', "~> 1.2.0"
   spec.add_development_dependency 'rspec', ">= 2.8.0"
   spec.add_development_dependency 'rdoc', ">= 3.12"
   spec.add_development_dependency 'bundler', ">= 1.0.0"

--- a/spec/omniauth/strategies/stable_spec.rb
+++ b/spec/omniauth/strategies/stable_spec.rb
@@ -2,13 +2,13 @@ require 'spec_helper'
 
 describe OmniAuth::Strategies::Stable do
   let(:access_token) { double('AccessToken', options: {}) }
-  let(:parsed_response) { stub('ParsedResponse') }
-  let(:response) { stub('Response', parsed: parsed_response) }
+  let(:parsed_response) { double('ParsedResponse') }
+  let(:response) { double('Response', parsed: parsed_response) }
 
   subject(:strategy) { described_class.new({}) }
 
   before do
-    strategy.stub(:access_token) { access_token }
+    allow(strategy).to receive(:access_token) { access_token }
   end
 
   context "client options" do
@@ -37,24 +37,24 @@ describe OmniAuth::Strategies::Stable do
 
   context "#email" do
     it 'returns email from raw_info if available' do
-      strategy.stub(:raw_info) { { 'email'  => 'email@example.com' } }
+      allow(strategy).to receive(:raw_info) { { 'email'  => 'email@example.com' } }
       expect(strategy.email).to eq('email@example.com')
     end
 
     it 'returns a blank string when there is no email in the raw_info' do
-      strategy.stub(:raw_info) { {} }
+      allow(strategy).to receive(:raw_info) { {} }
       expect(strategy.email).to eq('')
     end
   end
 
   context "#full_name" do
     it 'returns full_name from raw_info if available' do
-      strategy.stub(:raw_info) { { 'full_name'  => 'Taco Man' } }
+      allow(strategy).to receive(:raw_info) { { 'full_name'  => 'Taco Man' } }
       expect(strategy.full_name).to eq('Taco Man')
     end
 
     it 'returns a blank string when there is no full_name in the raw_info' do
-      strategy.stub(:raw_info) { {} }
+      allow(strategy).to receive(:raw_info) { {} }
       expect(strategy.full_name).to eq('')
     end
   end


### PR DESCRIPTION
Previous version omniauth-oauth2 1.1.x depended on oauth2 ~> 0.8, which depended on rack ~> 1.2, but Rails 5 depends on rack ~> 2.0

I tested against a Rails 4.2 app and it still worked. Is this the best version constraint to specify, or is there a better way to do it?